### PR TITLE
Refactor core API, add contact/government/location modules, update docs and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,33 +1,102 @@
 # pinoy-faker
->JavaScript Faker for Philippines
+
+> JavaScript faker utilities focused on Philippine test data.
+
+`pinoy-faker` helps you generate realistic sample values for common Filipino use cases like names, contact details, and government ID formats.
 
 ## Installation
 
-This is an opensource project for Filipino Developers looking for a faker 
-
- 
-  Install dependencies:
-
 ```bash
-$ npm install --save pinoy-faker
-```
-or
-
-```bash
-$ yarn add pinoy-faker
+npm install pinoy-faker
 ```
 
-## Usage
+## Quick start
 
-    const Faker  = require('pinoy-faker')
-    let randomFirstName = Faker.names.firstName(); // add params 1 or 0 for gender 
-    let randomLastName = Faker.names.lastName(); 
-    let randomFullName = Faker.names.fullName(); // add params 1 or 0 for gender 
+```js
+const faker = require('pinoy-faker');
 
-**Example:**
+console.log(faker.names.fullName());
+console.log(faker.contact.mobileNumber());
+console.log(faker.government.tin());
+console.log(faker.location.fullAddress());
+```
 
-``` js
-    const Faker  = require('pinoy-faker')
-    console.log(Faker.names.fullName())
-    // outputs: "Juan Dela Cruz"
+## API
+
+### `faker.names`
+
+Generate Filipino-style names.
+
+- `firstName(gender?)`
+  - `gender` can be `male`, `female`, `m`, `man`, `boy`, or numeric (`> 0` = male).
+  - If omitted, gender is randomized.
+- `lastName()`
+- `fullName(gender?)`
+
+```js
+faker.names.firstName(); // random
+faker.names.firstName('male');
+faker.names.lastName();
+faker.names.fullName('female');
+```
+
+### `faker.contact`
+
+Generate contact details with Philippine-friendly formats.
+
+- `mobileNumber()` → `09XXXXXXXXX`
+- `landlineNumber(areaCode = '02')` → `<areaCode>-XXXXXXX`
+- `emailAddress(name = 'juan.dela.cruz')`
+
+```js
+faker.contact.mobileNumber(); // e.g. 09171234567
+faker.contact.landlineNumber('032'); // e.g. 032-1234567
+faker.contact.emailAddress('Juan Dela Cruz'); // juan.dela.cruz@gmail.com
+```
+
+### `faker.government`
+
+Generate formatted mock government numbers for testing (not valid real IDs).
+
+- `tin()` → `XXX-XXX-XXX-XXX`
+- `sss()` → `XX-XXXXXXX-X`
+- `philHealth()` → `XX-XXXXXXXXX-X`
+- `pagIbig()` → `XXXX-XXXX-XXXX`
+
+```js
+faker.government.tin();
+faker.government.sss();
+faker.government.philHealth();
+faker.government.pagIbig();
+```
+
+### `faker.location`
+
+Generate Philippine location data.
+
+- `region()`
+- `province()`
+- `city()`
+- `barangay()`
+- `fullAddress()` → `{ region, province, city, barangay }`
+
+```js
+faker.location.region();
+faker.location.province();
+faker.location.city();
+faker.location.barangay();
+faker.location.fullAddress();
+```
+
+## Notes
+
+- Outputs are randomly generated strings intended for development/testing.
+- Generated government numbers follow formatting only and are not guaranteed to pass official validation rules.
+
+## Development
+
+Run tests:
+
+```bash
+npm test
 ```

--- a/index.js
+++ b/index.js
@@ -1,8 +1,15 @@
+const Names = require('./modules/names');
+const Contact = require('./modules/contact');
+const Government = require('./modules/government');
+const Location = require('./modules/location');
 
- const Names = require('./modules/names')
-function Faker (opts) {
-    let self = this;
-    opts = opts || {};
-    self.names  = new Names() 
+class Faker {
+  constructor() {
+    this.names = new Names();
+    this.contact = new Contact();
+    this.government = new Government();
+    this.location = new Location();
+  }
 }
-module.exports = new Faker()
+
+module.exports = new Faker();

--- a/modules/contact/index.js
+++ b/modules/contact/index.js
@@ -1,0 +1,45 @@
+const mobilePrefixes = [
+  '0905', '0906', '0907', '0908', '0909',
+  '0910', '0912', '0915', '0916', '0917', '0918', '0919',
+  '0920', '0921', '0922', '0923', '0925', '0926', '0927', '0928', '0929',
+  '0930', '0935', '0936', '0937', '0938', '0939',
+  '0945', '0946', '0947', '0948', '0949',
+  '0950', '0951', '0953', '0955', '0956',
+  '0961', '0963', '0965', '0966', '0967', '0968', '0969',
+  '0970', '0973', '0975', '0976', '0977', '0978', '0979',
+  '0981', '0989', '0994', '0995', '0996', '0997', '0998', '0999'
+];
+
+const emailDomains = [
+  'gmail.com',
+  'yahoo.com',
+  'outlook.com',
+  'hotmail.com',
+  'proton.me'
+];
+
+const randomInt = (max) => Math.floor(Math.random() * max);
+const randomDigits = (length) => Array.from({ length }, () => randomInt(10)).join('');
+const randomFrom = (values) => values[randomInt(values.length)];
+
+class Contact {
+  mobileNumber() {
+    return `${randomFrom(mobilePrefixes)}${randomDigits(7)}`;
+  }
+
+  landlineNumber(areaCode = '02') {
+    const normalizedAreaCode = String(areaCode).replace(/[^\d]/g, '') || '02';
+    return `${normalizedAreaCode}-${randomDigits(7)}`;
+  }
+
+  emailAddress(name = 'juan.dela.cruz') {
+    const safeName = String(name)
+      .trim()
+      .toLowerCase()
+      .replace(/[^a-z0-9._-]/g, '.');
+
+    return `${safeName || 'pinoy.user'}@${randomFrom(emailDomains)}`;
+  }
+}
+
+module.exports = Contact;

--- a/modules/government/index.js
+++ b/modules/government/index.js
@@ -1,0 +1,22 @@
+const randomInt = (max) => Math.floor(Math.random() * max);
+const randomDigits = (length) => Array.from({ length }, () => randomInt(10)).join('');
+
+class Government {
+  tin() {
+    return `${randomDigits(3)}-${randomDigits(3)}-${randomDigits(3)}-${randomDigits(3)}`;
+  }
+
+  sss() {
+    return `${randomDigits(2)}-${randomDigits(7)}-${randomDigits(1)}`;
+  }
+
+  philHealth() {
+    return `${randomDigits(2)}-${randomDigits(9)}-${randomDigits(1)}`;
+  }
+
+  pagIbig() {
+    return `${randomDigits(4)}-${randomDigits(4)}-${randomDigits(4)}`;
+  }
+}
+
+module.exports = Government;

--- a/modules/location/index.js
+++ b/modules/location/index.js
@@ -1,0 +1,66 @@
+const places = [
+  {
+    region: 'NCR',
+    province: 'Metro Manila',
+    city: 'Quezon City',
+    barangays: ['Batasan Hills', 'Commonwealth', 'Bagumbayan', 'Ugong Norte']
+  },
+  {
+    region: 'Region III',
+    province: 'Pampanga',
+    city: 'Angeles',
+    barangays: ['Balibago', 'Pampang', 'Pulung Maragul', 'Cutcut']
+  },
+  {
+    region: 'Region IV-A',
+    province: 'Laguna',
+    city: 'Calamba',
+    barangays: ['Pansol', 'Canlubang', 'Real', 'Parian']
+  },
+  {
+    region: 'Region VII',
+    province: 'Cebu',
+    city: 'Cebu City',
+    barangays: ['Lahug', 'Guadalupe', 'Mabolo', 'Talamban']
+  },
+  {
+    region: 'Region XI',
+    province: 'Davao del Sur',
+    city: 'Davao City',
+    barangays: ['Buhangin', 'Matina', 'Bunawan', 'Toril']
+  }
+];
+
+const randomInt = (max) => Math.floor(Math.random() * max);
+const randomFrom = (values) => values[randomInt(values.length)];
+
+class Location {
+  region() {
+    return randomFrom(places).region;
+  }
+
+  province() {
+    return randomFrom(places).province;
+  }
+
+  city() {
+    return randomFrom(places).city;
+  }
+
+  barangay() {
+    const place = randomFrom(places);
+    return randomFrom(place.barangays);
+  }
+
+  fullAddress() {
+    const place = randomFrom(places);
+    return {
+      region: place.region,
+      province: place.province,
+      city: place.city,
+      barangay: randomFrom(place.barangays)
+    };
+  }
+}
+
+module.exports = Location;

--- a/modules/names/index.js
+++ b/modules/names/index.js
@@ -4,39 +4,39 @@ const femaleFirstName = ["Aaliyah","Abagail","Abbey","Abbie","Abbigail","Abby","
             
 const lastName	= ["Álvarez","Órdenes","Abad","Abatayo","Abaya","Abayan","Abella","Aboitiz","Abracosa","Acebedo","Acevedo","Acosta","Acuña","Acuesta","Adlawan","Agbayani","Agcaoili","Aguilar","Agustín","Alba","Alcántar","Alcántara","Alcázar","Alcaraz","Aldo","Alegre","Alejandro","Alejo","Alférez","Alicante","Alonzo","Amparo","Amurao","Ancheta","Andal","Andrada","Aquino","Arabejo","Arancel","Araneta","Arboleda","Arce","Arcega","Arcilla","Areopagita","Astillo","Asunción","Atayde","Atega","Austria","Ayala","Azarcón","Bañaga","Balagtas","Balandra","Balangao","Balbutin","Baldonado","Balgos","Balingit","Baluyot","Banaag","Barcelona","Barerra","Barrameda","Barrientos","Basan","Batac","Bataller","Bautista","Baylosis","Bayona","Bayot","Belisario","Belleza","Bello","Belloso","Belmonte","Benítez","Benavides","Bernal","Bernardino","Bernardo","Bituin","Blanco","Bonachita","Bondoc","Bontia","Borja","Borres","Braña","Bristol","Buñag","Buclod","Buenaflor","Buenaventura","Buenavidez","Buenconsejo","Buendía","Buenpacífico","Bulan","Bustamante","Córdoba","Córdova","Cañada","Cabahug","Caballero","Cabangon","Cabrales","Cabrera","Cabungcal","Cachuela","Cadiz","Calañas","Calamba","Canencia","Canlas","Cantillo","Caparas","Capili","Capillo","Capistrano","Capulong","Carandang","Cariño","Caringal","Carrasco","Casis","Castañares","Castañeda","Castillo","Castro","Catacutan","Catapang","Catindig","Catubig","Cayabyab","Cayetano","Celiz","Cembrano","Ceniza","Centino","Cereza","Cerezo","Cerinza","Cervantes","Chávez","Chio","Claridad","Clemente","Concepción","Cordero","Corporal","Corpuz","Costales","Cruz","Cruzada","Cuenca","Cuenco","Cueva","Cuevas","Cunanan","Custodio","Díaz","Dabi","Daclan","Dagohoy","Dalangin","Dalisay","Dantes","Davao","Dayag","Decatoria","Defensor","Degayo","Deocampo","Deseo","Desiderio","Despujol","Digamon","Dilag","Dimaano","Dimaculangan","Dimalanta","Dimaunahan","Dimayuga","Divinagracia","Diwata","Domínguez","Domingo","Duarna","Duarte","Dueñas","Dulay","Dulce","Dumlao","Dungog","Elefante","Elizalde","Ello","Elorza","Encela","Ereve","Escaño","Escalante","Escribano","España","Español","Espejo","Esquivias","Estillore","Estolas","Estrada","Estrella","Etrone","Europa","Eusebio","Evangelista","Fajardo","Fandiño","Fazon","Felongco","Fernández","Fernando","Ferrer","Flores","Fontanilla","Formalouza","Francisco","Gómez","Gahol","Galéndez","Galíndez","Galang","Galit","Galleros","Galura","Galvez","Gamulo","García","Gatchalian","Gatdula","Gatmaitan","Gatus","Gica","Gil","Gonzáles","González","Gonzaga","Goyena","Guadarrama","Guerra","Guevara","Guevarra","Guinto","Gutiérrez","Halili","Hermano","Hernández","Herrera","Hinojosa","Hojas","Hontiveros","Ignacio","Ilagan","Inárez","Infanta","Infante","Iriberri","Isidro","Isip","Jabillo","Jacinto","Jalandoni","Jardenil","Javier","Jiménez","Jugueta","Kalaw","Katigbak","Lázaro","López","Labrador","Lacanilao","Lacsamana","Ladera","Lagman","Lagmay","Lansangan","Lara","Laurel","Lavares","Leaño","Legaspí","Legazpí","Leones","Libunao","Lindo","Lingao","Liwag","Liwanag","Lontoc","Lontok","Lorenzo","Lorete","Lualhati","Luz","Méndez","Mañalac","Macalinao","Macalintal","Macalipay","Macaraeg","Macaraig","Macasaet","Macatangay","Macrohon","Madrid","Madrigal","Magallanes","Magalona","Magbanua","Magno","Magpantay","Magsakay","Magsino","Magtibay","Makalintal","Malabanan","Malaluan","Malano","Malapitan","Malicdem","Mallari","Mamaril","Manabat","Manahan","Manalang","Manalastas","Manalili","Manalo","Manaloto","Manansala","Mangahas","Mangubat","Manjón","Manlangit","Manrique","Manzano","Maquiling","Maranan","Marasigan","Marcelo","Mariano","Marquez","Martínez","Masancay","Masangkay","Matías","Matias","Mayor","Medel","Medina","Mención","Mendoza","Mercadejas","Mercado","Mesías","Micolob","Miedes","Millares","Mindoro","Mineque","Mipa","Miranda","Monceda","Montano","Montecillo","Montederamos","Montelibano","Monteloyola","Montenegro","Montero","Monteverde","Montilla","Monzón","Moreno","Muñoz","Munsayac","Murcia","Nallos","Natividad","Natural","Naval","Navarro","Navidad","Niévez","Ocampo","Olarte","Opulencia","Orante","Osorio","Ouano","Pérez","Padilla","Paglinawan","Paguio","Palad","Paloma","Pamintuan","Pamplona","Panaligan","Pangan","Panganiban","Pangilinan","Panlilio","Panopio","Paraíso","Parrilla","Parungao","Pasa","Pastor","Patacsil","Pavia","Payumo","Pelayo","Piñero","Piatos","Pilapil","Pizarro","Ponferrada","Portugal","Presidente","Prieto","Puentespina","Puno","Punzalan","Quema","Querubín","Quezada","Quiñones","Ramírez","Ramientos","Ramos","Rana","Razón","Recio","Recto","Regis","Relleve","Rendón","Reoja","Reyes","Riego","Rillo","Rioja","Rivera","Roa","Robles","Roces","Rodríguez","Rojas","Romblon","Romero","Roque","Rosales","Rosario","Roxas","Rubio","Ruedas","Sánchez","Sace","Salazar","Salinas","Salonga","Salvador","Sambrano","Samonte","Sandoval","Santiago","Santillán","Santos","Sardido","Sarmiento","Sarte","Sevilla","Sibug","Sicat","Silva","Silvestre","Solas","Soler","Solivio","Sombilon","Soriano","Suarez","Subejano","Sulit","Sullano","Tañag","Talavér","Talion","Tamayo","Tanilon","Tanyag","Taruc","Tayag","Tejada","Tibayan","Togonon","Tolosa","Torrealba","Torres","Tortal","Tugonon","Tumulak","Tupas","Umali","Urbina","Valdez","Valencia","Valle","Vargas","Vega","Velasco","Veluz","Ventura","Verano","Veterano","Vicente","Vilela","Villaécija","Villamar","Villamor","Villanueva","Villarin","Villarino","Villaromán","Villarosa","Villaruz","Villegas","Villosillo","Viray","Vitug","Vizcaya","Yabut","Yao","Ylagan","Yllana","Zabala","Zacarías","Zafra","Zamora","Zarate","Zoleta","Zulueta", "Abandarios","Abantas","Abas","Abaygar","Abbas","Abdul","Abdulrahman","Abe","Abrogar","Abu","Abubacar","Abubakar","Abucay","Abulog","Abyyappy","Acbar","Adams","Adamson","Adil","Adiong","Adona","Agatep","Agbayani","Ahkiong","Akbar","Ala","Ali","Aliguyon","Alimboyugen","Allanic","Alonto","Alupay","Ambulo","Amer","Amerol","Amora","Ampaso","Ampatuan","Ampuan","Amurao","Ancatan","Anderson","Andong","Andrews","Angping","Aniban","Aradji","Arai","Arimao","Ausan","Ayson","Azis","Baal","Baang","Bahandi","Bailey","Bakil","Baldedara","Balignasay","Balindong","Baltar","Banog","Bansagnon","Bantuas","Barrometro","Basher","Bashir","Basir","Batac","Batara","Batungbakal","Begtang","Bello","Bengco","Bengzon","Bennet","Biag","Biglang-Awa","Bilatan","Binatara","Bitangcol","Bitao","Bogabong","Bongalos","Brown","Bryant","Buat","Budi","Buncio","Burton","Busran","Butil","Buyco","Cabatingan","Cabigas","Cadar","Cader","Cagas","Calaguas","Calapatia","Caldero","Calim","Calunod","Camama","Camara","Camat","Campong","Canasa","Cangco","Canumay","Capati","Capil","Capongga","Carandang","Carim","Caris","Casan","Casicas","Catacutan","Cawayan","Cayabyab","Cayawan","Cayco","Cayubyub","Chanbonpin","Chanco","Chengco","Chincuanco","Ching","Chiongbian","Chionglo","Choa","Choochan","Chua","Chuakay","Chuchu","Chuidian","Ciocon","Clark","Co","Cojuangco","Cojuangco","Collins","Concon","Congco","Congson","Coquia","Cosalan","Cox","Cuajunco","Cuajungco","Cuyegkeng","Dacanay","Dacudag","Dacudao","Daculug","Dagala","Dahil-Dahil","Dahilan","Dalrymple","Daplas","Datu","Datu-imam","Davis","Day","De Pan","Deang","Dee","Deonzon","Diamzon","Dianalan","Dilangalen","Dilanggalen","Dimaano","Dimaguiba","Dimakuta","Dimaunahan","Dimson","Dinaluyan","Dinguinbayan","Dinlayan","Diokno","Diongon","Dioquino","Dipatuan","Disomimba","Diuata","Divero","Diwata","Dizon","Dofitas","Dulalas","Dumalahay","Dumaloan","Dumlao","Dura","Dy","Dyquiangco","Dysangco","Ebrahim","Fitzpatrick","Fujimori","Fuller","Gabuat","Gabuyo","Galit","Gallóra","Gallano","Gandionco","Ganzon","Gatan","Goking","Gordon","Gosiengfiao","Gosoc","Gosum","Gray","Griffin","Guanlao","Guanzon","Gubat","Guiao","Guimatao","Guinto","Guro","Habibi","Hadjirul","Hagedorn","Hakamada","Hamada","Hamid","Harata","Henson","Hill","Hizon","Hopkins","Howard","Humilde","Hung","Hussein","Ibrahim","Ide","Ifugao","Iitaoka","Ilaban","Inoue","Ishida","Ishii","Ishiizu","Ison","Iwatani","James","Janani","Jante","Japos","Japson","Jenkins","Joco","Jocson","Jones","Joson","Jubail","Junco","Kalawakan","Kali","Kalim","Kamad","Kanaway","Kaneko","Kato","Kaunlaran","Keller","Kilayko","Kimimoto","Kimpo","Kimura","King","Kiong","Kishimoto","Kison","Kobayashi","Koizumi","Kulikutan","Kulubot","Kumulitog","Labasan","Labong","Labuguen","Lacan","Lacandola","Lacandula","Lacro","Lacsamana","Lacsina","Lacson","Lakan","Lakandula","Lambert","Lanta","Lantin","Lao-lao","Latif","Latip","Lauzon","Lavapiz","Lawsin","Laxamana","Lazaro","Lemoncito","Leng","Leones","Leyco","Leyson","Liamzon","Lim","Limbaco","Limbudan","Limcangco","Limcuando","Limgo","Limjap","Limsin","Limson","Limuaco","Linganyan","Liongson","Locsin","Logan","Lomondot","Long","Lopa","Loshang","Lozo","Luansing","Lucman","Lumaad","Lumas-e","Lumeran","Luso-Luso","Macalipay","Macapodi","Macaraeg","Macaspac","Macawili","Macodi","Madid","Madlambayan","Madlangbayan","Magaling","Magan","Magat","Magbantay","Magbanua","Magday","Magdiwang","Maglalang","Maglikian","Magnaye","Magos","Magpantay","Magpulong","Magsaysay","Magsino","Magtoto","Mahiya","Maitim","Makabaligoten","Makadaan","Makisig","Mala","Malagar","Malaki","Malambut","Maliit","Malit","Mallari","Malubay","Manansala","Manese","Mangao","Mangayao","Mangsinco","Mangubat","Mangurun","Manigbas","Maniri","Manlapaz","Manyakes","Mapandi","Maputi","Marapao","Martins","Maruhom","Maruhombsar","Masipag","Mastura","Matapang","Matiyaga","Matsuda","Matsunaga","McAleese","McCrae","McKnight","Menese","Meneses","Miyaki","Mohammad","Monton","Monzon","Morgan","Mori","Morris","Moxcir","Munder","Muraoka","Murro","Mutia","Mutya","Nacu","Naga","Nakamura","Nang","Nangpi","Nasser","Nato","Navea","Nazar","Neal","O'Neal","Olan","Omar","Ong","Ongpauco","Ongpin","Ongsioco","Otogan","Paña","Pabalan","Pabustan","Paca","Pagsisihan","Palad","Paloma","Pamintuan","Panantaon","Pandapatan","Pandi","Panonce","Panumpang","Paragili","Parker","Parsaligan","Patanindagat","Paulin","Pecore","Pecson","Pendatun","Peria","Peterson","Phillips","Piaoan","Pichicoy","Pilapil","Pildilapil","Pinagbuklod","Pinagdamutan","Pinagpala","Pinga","Posangco","Puti","Quengua","Quetua","Quiambao","Quiason","Quibin","Quiblat","Quibuyen","Quicho","Quimbo","Quimino","Quimque","Quimson","Quindipan","Quingco","Quiocho","Quiocson","Quiogue","Quison","Quisumbing","Racman","Raffles","Rahman","Rasul","Reading","Relano","Reotutar","Rice","Ricketts","Ringia","Russel","Saiden","Salalila","Salapuddin","Salapudin","Salem","Sali","Salim","Salipada","Salumbides","Salumbidez","Sampulna","Samson","Sanderson","Sangco","Sanqui","Sarip","Saripada","Sariua","Sariwa","Sason","Sato","Sayson","Serad","Sese","Sharif","Sharip","Shiochi","Sia","Siapuatco","Siazon","Simangan","Simpao","Simsuangco","Sinagtala","Sinclair","Singco","Singson","Sinsuat","Siongco","Sioson","Sipin","Sipsip","Siso","Sison","Smith","Solmoro","Songco","Songcuya","Suaco","Suasi","Subrabas","Suico","Sultan","Sumague","Suntay","Supsup","Sususco","Suzuki","Sycip","Sydiongco","Syjuco","Syquia","Sytengco","Tabilla","Tagaan","Tagonon","Tala","Talatala","Talaugon","Talon","Talong","Tambuatco","Tan","Tanaka","Tangco","Tangkiang","Tanhehco","Tanjuatco","Tanjutco","Tansiongco","Tapalla","Tauli","Tawan","Taylor","Tecson","Tengco","Tiamson","Tiangco","Tiaoqui","Tio","Tiolengco","Tiong","Tiongco","Tiongson","Tiongson","Tiu","Tizon","Tongson","Tsukada","Tuazon","Tubo","Tubongbanua","Tugonon","Tuico","Tumulak","Tungol","Tupa","Tupas","Tupaz","Umpa","Umpar","Usman","Uson","Uy","Uy","Uysiuseng","Uytengsu","Vianzon","Vinzon","Vital","Vitug","Vivas","Wang","Wang-od","Ward","West","Wood","Yalung","Yamada","Yamamoto","Yamato","Yamazaki","Yambao","Yamson","Yance","Yap","Yapchulay","Yaptinchay","Yatco","Yengko","Ynaya","Yongque","Yoshida","Yoshikawa","Yoshizaki","Yu","Yuan","Yujeco","Yujuico","Yulo","Yunsay","Yusi","Yuson"]
 
-const generateMale =()=>maleFirstName[Math.floor(Math.random() * maleFirstName.length)]
-const generateFemale =()=>femaleFirstName[Math.floor(Math.random() * femaleFirstName.length)]
-const generateLastName =()=>lastName[Math.floor(Math.random() * lastName.length)]
-function Names(){ 
+const randomFrom = (values) => values[Math.floor(Math.random() * values.length)];
 
-    this.lastName =  function(){
-            return generateLastName()
-    }
-    
-    this.firstName = function (gender){
-         if(!gender){
-           gender = Math.floor(Math.random() * Math.floor(2))
-         }
-         console.log(gender)
-         if(gender>0){
-            return generateMale()
-         }
-         return generateFemale()
-        }
+const normalizeGender = (gender) => {
+  if (gender === undefined || gender === null) {
+    return Math.floor(Math.random() * 2) === 1 ? 'male' : 'female';
+  }
 
+  if (typeof gender === 'number') {
+    return gender > 0 ? 'male' : 'female';
+  }
 
-    this.fullName = function (gender){
-        if(!gender){
-          gender = Math.floor(Math.random() * Math.floor(2))
-        }
-        console.log(gender)
-        if(gender>0){
-           return `${generateMale()} ${generateLastName()}`
-        }
-        return `${generateFemale()} ${generateLastName()}`
-       }
-   }
-module['exports'] = Names;
+  const normalized = String(gender).toLowerCase();
+  if (['male', 'm', 'boy', 'man'].includes(normalized)) {
+    return 'male';
+  }
 
-    
- 
+  return 'female';
+};
+
+class Names {
+  lastName() {
+    return randomFrom(lastName);
+  }
+
+  firstName(gender) {
+    return normalizeGender(gender) === 'male'
+      ? randomFrom(maleFirstName)
+      : randomFrom(femaleFirstName);
+  }
+
+  fullName(gender) {
+    return `${this.firstName(gender)} ${this.lastName()}`;
+  }
+}
+
+module.exports = Names;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,16 @@
 {
   "name": "pinoy-faker",
-  "version": "1.0.0",
-  "lockfileVersion": 1
+  "version": "1.2.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "pinoy-faker",
+      "version": "1.2.0",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    }
+  }
 }

--- a/package.json
+++ b/package.json
@@ -1,10 +1,10 @@
 {
   "name": "pinoy-faker",
-  "version": "1.0.11",
-  "description": "JavaScript Faker for Pinoy 😊",
+  "version": "1.2.0",
+  "description": "JavaScript Faker for Philippines",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\"",
+    "test": "node --test",
     "start": "node index.js"
   },
   "keywords": [
@@ -15,11 +15,14 @@
     "philhealth",
     "philippines",
     "pinoy",
-    "pinoy-js-developer",
-    "faker"
+    "faker",
+    "tin",
+    "pag-ibig"
   ],
   "author": "John Ben Uera",
   "license": "MIT",
-  "homepage": "https://github.com/nebnhoj/pinoy-faker"
-
+  "homepage": "https://github.com/nebnhoj/pinoy-faker",
+  "engines": {
+    "node": ">=18"
+  }
 }

--- a/test/faker.test.js
+++ b/test/faker.test.js
@@ -1,0 +1,36 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const Faker = require('../index');
+
+test('name generator returns strings', () => {
+  assert.equal(typeof Faker.names.firstName(), 'string');
+  assert.equal(typeof Faker.names.lastName(), 'string');
+  assert.equal(typeof Faker.names.fullName('male'), 'string');
+});
+
+test('contact generator returns Philippine-like formats', () => {
+  assert.match(Faker.contact.mobileNumber(), /^09\d{9}$/);
+  assert.match(Faker.contact.landlineNumber(), /^\d{2}-\d{7}$/);
+  assert.match(Faker.contact.emailAddress('Maria Clara'), /^maria.clara@[a-z.]+$/);
+});
+
+test('government ids return expected format', () => {
+  assert.match(Faker.government.tin(), /^\d{3}-\d{3}-\d{3}-\d{3}$/);
+  assert.match(Faker.government.sss(), /^\d{2}-\d{7}-\d$/);
+  assert.match(Faker.government.philHealth(), /^\d{2}-\d{9}-\d$/);
+  assert.match(Faker.government.pagIbig(), /^\d{4}-\d{4}-\d{4}$/);
+});
+
+test('location generator returns region, province, city and barangay', () => {
+  assert.equal(typeof Faker.location.region(), 'string');
+  assert.equal(typeof Faker.location.province(), 'string');
+  assert.equal(typeof Faker.location.city(), 'string');
+  assert.equal(typeof Faker.location.barangay(), 'string');
+
+  const fullAddress = Faker.location.fullAddress();
+  assert.equal(typeof fullAddress.region, 'string');
+  assert.equal(typeof fullAddress.province, 'string');
+  assert.equal(typeof fullAddress.city, 'string');
+  assert.equal(typeof fullAddress.barangay, 'string');
+});


### PR DESCRIPTION
### Motivation

- Provide a cleaner, class-based API surface for the faker and expand functionality beyond names to include contact info, government IDs, and location data.
- Improve usability by normalizing gender inputs and producing Philippine-friendly formats for common test data.

### Description

- Replace the old factory with a `Faker` class in `index.js` that exposes `names`, `contact`, `government`, and `location` modules via `module.exports = new Faker()`.
- Refactor `modules/names/index.js` to a `Names` class with a `normalizeGender` helper and more robust `firstName`, `lastName`, and `fullName` implementations.
- Add new modules `modules/contact/index.js`, `modules/government/index.js`, and `modules/location/index.js` to generate Philippine-style mobile/landline/email, formatted mock government IDs, and location/address pieces respectively.
- Update documentation in `README.md` to describe the new API and add examples, bump package `version` and `engines` in `package.json`, and update `package-lock.json` accordingly.
- Add test suite `test/faker.test.js` and change the `test` script to run `node --test`.

### Testing

- Added unit tests in `test/faker.test.js` that exercise `names`, `contact`, `government`, and `location` outputs and assert expected string/format patterns using Node's built-in test runner and `assert`.
- Ran the test suite with `npm test` (which uses `node --test`) and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a1a955e4d48331bc8d0cdf2d27c2ef)