### PR TITLE
Add Filipino foods faker module

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ console.log(faker.names.fullName());
 console.log(faker.contact.mobileNumber());
 console.log(faker.government.tin());
 console.log(faker.location.fullAddress());
+console.log(faker.foods.food());
 ```
 
 ## API
@@ -94,6 +95,29 @@ faker.location.province('Region III');
 faker.location.city('Cebu');
 faker.location.barangay('Quezon City');
 faker.location.fullAddress();
+```
+
+
+### `faker.foods`
+
+Generate common Filipino food names.
+
+- `dishes()` -> all supported ulam/main dishes
+- `streetFoods()` -> all supported Filipino street food items
+- `desserts()` -> all supported dessert/snack items
+- `dish()`
+- `streetFood()`
+- `dessert()`
+- `food()` -> random item from all food lists
+
+```js
+faker.foods.dishes();
+faker.foods.streetFoods();
+faker.foods.desserts();
+faker.foods.dish();
+faker.foods.streetFood();
+faker.foods.dessert();
+faker.foods.food();
 ```
 
 ## Notes

--- a/index.js
+++ b/index.js
@@ -2,6 +2,7 @@ const Names = require('./modules/names');
 const Contact = require('./modules/contact');
 const Government = require('./modules/government');
 const Location = require('./modules/location');
+const Foods = require('./modules/foods');
 
 class Faker {
   constructor() {
@@ -9,6 +10,7 @@ class Faker {
     this.contact = new Contact();
     this.government = new Government();
     this.location = new Location();
+    this.foods = new Foods();
   }
 }
 

--- a/modules/foods/index.js
+++ b/modules/foods/index.js
@@ -1,0 +1,84 @@
+const dishes = [
+  'Adobo',
+  'Sinigang',
+  'Kare-Kare',
+  'Lechon',
+  'Pancit Canton',
+  'Bulalo',
+  'Laing',
+  'Bicol Express',
+  'Kaldereta',
+  'Mechado',
+  'Afritada',
+  'Tinola',
+  'Dinuguan',
+  'Sisig',
+  'Chicken Inasal',
+  'Batchoy',
+  'Pinakbet',
+  'Arroz Caldo',
+  'Lomi',
+  'Pochero'
+];
+
+const streetFoods = [
+  'Isaw',
+  'Kwek-kwek',
+  'Fish Ball',
+  'Kikiam',
+  'Betamax',
+  'Adidas',
+  'Proben',
+  'Banana Cue',
+  'Camote Cue',
+  'Turon',
+  'Taho',
+  'Balut'
+];
+
+const desserts = [
+  'Halo-Halo',
+  'Leche Flan',
+  'Bibingka',
+  'Puto Bumbong',
+  'Buko Pandan',
+  'Maja Blanca',
+  'Ube Halaya',
+  'Sapin-Sapin',
+  'Kutsinta',
+  'Pichi-Pichi'
+];
+
+const randomFrom = (values) => values[Math.floor(Math.random() * values.length)];
+
+class Foods {
+  dishes() {
+    return [...dishes];
+  }
+
+  streetFoods() {
+    return [...streetFoods];
+  }
+
+  desserts() {
+    return [...desserts];
+  }
+
+  dish() {
+    return randomFrom(dishes);
+  }
+
+  streetFood() {
+    return randomFrom(streetFoods);
+  }
+
+  dessert() {
+    return randomFrom(desserts);
+  }
+
+  food() {
+    return randomFrom([...dishes, ...streetFoods, ...desserts]);
+  }
+}
+
+module.exports = Foods;

--- a/test/faker.test.js
+++ b/test/faker.test.js
@@ -39,3 +39,14 @@ test('location generator returns complete lookup arrays and random values', () =
   assert.equal(typeof fullAddress.city, 'string');
   assert.equal(typeof fullAddress.barangay, 'string');
 });
+
+test('foods generator returns filipino food data', () => {
+  assert.ok(Faker.foods.dishes().includes('Adobo'));
+  assert.ok(Faker.foods.streetFoods().includes('Isaw'));
+  assert.ok(Faker.foods.desserts().includes('Halo-Halo'));
+
+  assert.equal(typeof Faker.foods.dish(), 'string');
+  assert.equal(typeof Faker.foods.streetFood(), 'string');
+  assert.equal(typeof Faker.foods.dessert(), 'string');
+  assert.equal(typeof Faker.foods.food(), 'string');
+});


### PR DESCRIPTION
### Motivation

- Provide a simple faker API for common Filipino foods (ulam/main dishes, street foods, desserts) to support generating realistic sample food names.
- Expose the foods API from the main package so consumers can call `faker.foods` alongside existing generators.

### Description

- Add `modules/foods/index.js` implementing curated arrays for `dishes`, `streetFoods`, and `desserts` plus list getters and random generators `dish()`, `streetFood()`, `dessert()`, and `food()`.
- Wire the new module into the package entrypoint by instantiating it on `faker` as `this.foods` in `index.js`.
- Update `README.md` Quick Start and API docs to document `faker.foods` usage and methods.
- Add test coverage in `test/faker.test.js` that asserts known food entries exist and that the random generators return strings.

### Testing

- Ran the test suite with `npm test`, which executed the added food tests plus existing tests and all tests passed (5 tests, 0 failures).
- Tests validate list contents (`Adobo`, `Isaw`, `Halo-Halo`) and return types for the random generators (`dish`, `streetFood`, `dessert`, `food`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a1b852c3988331a826a94cac57ef73)